### PR TITLE
Ajout d'une condition supplémentaire dans le workflow CI/CD pour s'as…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -174,7 +174,7 @@ jobs:
     concurrency:
       group: deploy-prod
       cancel-in-progress: true
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == true
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
 
     steps:
       - name: Fake production deployment


### PR DESCRIPTION
…surer que le déploiement en production ne se produit que si la branche de base de la pull request est 'main'.